### PR TITLE
Add department dropdown

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -18,6 +18,7 @@ interface ChatInterfaceProps {
     id: string;
     title: string;
     description: string;
+    department: string;
     ai_conversation: Message[];
   };
   onBack: () => void;
@@ -157,7 +158,7 @@ Lad os sammen udvikle idéen uden svære fagudtryk. Husk, næsten alt kan lade s
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="text-sm text-muted-foreground bg-primary-light p-3 rounded-lg">
-          <strong>Arbejder med:</strong> {suggestion.title}
+          <strong>Arbejder med:</strong> {suggestion.title} ({suggestion.department})
         </div>
         
         <ScrollArea className="h-96 pr-4">

--- a/src/components/SuggestionForm.tsx
+++ b/src/components/SuggestionForm.tsx
@@ -5,22 +5,31 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Lightbulb, Send } from 'lucide-react';
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select';
 
 interface SuggestionFormProps {
-  onSubmit: (title: string, description: string) => void;
+  onSubmit: (title: string, description: string, department: string) => void;
   loading?: boolean;
 }
 
 const SuggestionForm = ({ onSubmit, loading = false }: SuggestionFormProps) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [department, setDepartment] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (title.trim() && description.trim()) {
-      onSubmit(title.trim(), description.trim());
+    if (title.trim() && description.trim() && department) {
+      onSubmit(title.trim(), description.trim(), department);
       setTitle('');
       setDescription('');
+      setDepartment('');
     }
   };
 
@@ -48,23 +57,40 @@ const SuggestionForm = ({ onSubmit, loading = false }: SuggestionFormProps) => {
           </div>
           <div className="space-y-2">
             <Label htmlFor="description">Beskrivelse</Label>
-            <Textarea
-              id="description"
-              placeholder="Beskriv din idé. AI hjælper med at forbedre den."
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={4}
-              required
-            />
-          </div>
-          <Button 
-            type="submit" 
-            className="w-full" 
-            disabled={loading || !title.trim() || !description.trim()}
-          >
-            {loading ? 'Opretter forslag...' : 'Start AI-samarbejde'}
-            <Send className="ml-2 w-4 h-4" />
-          </Button>
+          <Textarea
+            id="description"
+            placeholder="Beskriv din idé. AI hjælper med at forbedre den."
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="department">Afdeling</Label>
+          <Select value={department} onValueChange={setDepartment}>
+            <SelectTrigger id="department" className="w-full">
+              <SelectValue placeholder="Vælg afdeling" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="salg">Salg</SelectItem>
+              <SelectItem value="marketing">Marketing</SelectItem>
+              <SelectItem value="indkøb">Indkøb</SelectItem>
+              <SelectItem value="design">Design</SelectItem>
+              <SelectItem value="lager">Lager</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={
+            loading || !title.trim() || !description.trim() || !department
+          }
+        >
+          {loading ? 'Opretter forslag...' : 'Start AI-samarbejde'}
+          <Send className="ml-2 w-4 h-4" />
+        </Button>
           <p className="text-xs text-muted-foreground text-center">
             Dine idéer hjælper os med at forbedre børnetøj
           </p>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -15,6 +15,7 @@ interface Suggestion {
   id: string;
   title: string;
   description: string;
+  department: string;
   status: 'pending' | 'approved' | 'rejected';
   ai_conversation: Array<{ role: 'user' | 'assistant'; content: string }>;
   admin_notes?: string;
@@ -98,7 +99,8 @@ const Admin = () => {
         ...item,
         status: item.status as 'pending' | 'approved' | 'rejected',
         ai_conversation: (item.ai_conversation as any) || [],
-        profiles: profilesMap.get(item.user_id) || null
+        profiles: profilesMap.get(item.user_id) || null,
+        department: item.department
       }));
       
       setSuggestions(typedSuggestions);
@@ -279,6 +281,9 @@ const Admin = () => {
                         <p className="text-sm text-muted-foreground mb-2">
                           af {suggestion.profiles?.full_name || 'Ukendt bruger'}
                         </p>
+                        <p className="text-xs text-muted-foreground mb-2 capitalize">
+                          Afdeling: {suggestion.department}
+                        </p>
                         <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
                           {suggestion.description}
                         </p>
@@ -319,8 +324,11 @@ const Admin = () => {
                             <div className="space-y-4">
                               <div>
                                 <h4 className="font-semibold mb-2">Oprindeligt forslag</h4>
-                                <div className="p-3 bg-muted rounded-lg">
+                                <div className="p-3 bg-muted rounded-lg space-y-2">
                                   <p className="text-sm">{suggestion.description}</p>
+                                  <p className="text-xs text-muted-foreground capitalize">
+                                    Afdeling: {suggestion.department}
+                                  </p>
                                 </div>
                               </div>
                               
@@ -414,12 +422,15 @@ const Admin = () => {
               <div className="space-y-3">
                 {reviewedSuggestions.slice(0, 5).map((suggestion) => (
                   <div key={suggestion.id} className="flex items-center justify-between p-3 border rounded-lg">
-                    <div>
-                      <p className="font-medium">{suggestion.title}</p>
-                      <p className="text-sm text-muted-foreground">
-                        af {suggestion.profiles?.full_name || 'Ukendt bruger'}
-                      </p>
-                    </div>
+                  <div>
+                    <p className="font-medium">{suggestion.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      af {suggestion.profiles?.full_name || 'Ukendt bruger'}
+                    </p>
+                    <p className="text-xs text-muted-foreground capitalize">
+                      Afdeling: {suggestion.department}
+                    </p>
+                  </div>
                     <Badge className={getStatusColor(suggestion.status)} variant="outline">
                       {getStatusIcon(suggestion.status)}
                       <span className="ml-1">{suggestion.status}</span>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ interface Suggestion {
   id: string;
   title: string;
   description: string;
+  department: string;
   status: 'pending' | 'approved' | 'rejected';
   ai_conversation: any[];
   created_at: string;
@@ -71,7 +72,11 @@ const Dashboard = () => {
     }
   };
 
-  const createSuggestion = async (title: string, description: string) => {
+  const createSuggestion = async (
+    title: string,
+    description: string,
+    department: string
+  ) => {
     if (!user) return;
 
     try {
@@ -82,6 +87,7 @@ const Dashboard = () => {
           user_id: user.id,
           title,
           description,
+          department,
           status: 'pending'
         })
         .select()
@@ -218,14 +224,17 @@ const Dashboard = () => {
                           <h3 className="font-semibold">{suggestion.title}</h3>
                           <div className="flex items-center gap-2">
                             {getStatusIcon(suggestion.status)}
-                            <Badge 
-                              variant="secondary" 
+                            <Badge
+                              variant="secondary"
                               className={getStatusColor(suggestion.status)}
                             >
                               {suggestion.status}
                             </Badge>
                           </div>
                         </div>
+                        <p className="text-xs mb-1 capitalize text-muted-foreground">
+                          Afdeling: {suggestion.department}
+                        </p>
                         <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
                           {suggestion.description}
                         </p>

--- a/supabase/migrations/20250731100000_add_department_column.sql
+++ b/supabase/migrations/20250731100000_add_department_column.sql
@@ -1,0 +1,4 @@
+-- Add department column to suggestions table
+ALTER TABLE public.suggestions
+ADD COLUMN department TEXT NOT NULL DEFAULT 'salg' CHECK (department IN ('salg', 'marketing', 'indkøb', 'design', 'lager'));
+


### PR DESCRIPTION
## Summary
- add department field in SuggestionForm with dropdown options
- store department on new suggestions and display in Dashboard and Admin
- show department info during AI chat
- add supabase migration to support department column

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6889ef9ef9e0832ebf66ca615dae1d0d