### PR TITLE
Auto-generate titles & add night mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
+import { ModeToggle } from "./components/ModeToggle";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
@@ -19,6 +20,9 @@ const App = () => (
         <Toaster />
         <Sonner />
         <BrowserRouter>
+          <div className="fixed top-4 right-4 z-50">
+            <ModeToggle />
+          </div>
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/auth" element={<Auth />} />

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,0 +1,17 @@
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+import { Sun, Moon } from "lucide-react";
+
+export const ModeToggle = () => {
+  const { theme, setTheme } = useTheme();
+  const toggle = () => setTheme(theme === "dark" ? "light" : "dark");
+
+  return (
+    <Button variant="outline" size="icon" onClick={toggle}>
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};
+

--- a/src/components/SuggestionForm.tsx
+++ b/src/components/SuggestionForm.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Lightbulb, Send } from 'lucide-react';
+import { Send } from 'lucide-react';
 import {
   Select,
   SelectTrigger,
@@ -14,20 +13,18 @@ import {
 } from '@/components/ui/select';
 
 interface SuggestionFormProps {
-  onSubmit: (title: string, description: string, department: string) => void;
+  onSubmit: (description: string, department: string) => void;
   loading?: boolean;
 }
 
 const SuggestionForm = ({ onSubmit, loading = false }: SuggestionFormProps) => {
-  const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [department, setDepartment] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (title.trim() && description.trim() && department) {
-      onSubmit(title.trim(), description.trim(), department);
-      setTitle('');
+    if (description.trim() && department) {
+      onSubmit(description.trim(), department);
       setDescription('');
       setDepartment('');
     }
@@ -45,16 +42,6 @@ const SuggestionForm = ({ onSubmit, loading = false }: SuggestionFormProps) => {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="title">Titel</Label>
-            <Input
-              id="title"
-              placeholder="F.eks. nyt børnetøjsdesign eller produktforbedring"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
-          </div>
           <div className="space-y-2">
             <Label htmlFor="description">Beskrivelse</Label>
           <Textarea
@@ -85,7 +72,7 @@ const SuggestionForm = ({ onSubmit, loading = false }: SuggestionFormProps) => {
           type="submit"
           className="w-full"
           disabled={
-            loading || !title.trim() || !description.trim() || !department
+            loading || !description.trim() || !department
           }
         >
           {loading ? 'Opretter forslag...' : 'Start AI-samarbejde'}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from './components/theme-provider'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <App />
+  </ThemeProvider>
+);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -83,8 +83,12 @@ const Dashboard = () => {
     }
   };
 
+  const generateTitle = (description: string) => {
+    const words = description.trim().split(/\s+/).slice(0, 5);
+    return words.join(' ') + (words.length === 5 ? '...' : '');
+  };
+
   const createSuggestion = async (
-    title: string,
     description: string,
     department: string
   ) => {
@@ -96,7 +100,7 @@ const Dashboard = () => {
         .from('suggestions')
         .insert({
           user_id: user.id,
-          title,
+          title: generateTitle(description),
           description,
           department,
           status: 'pending'


### PR DESCRIPTION
## Summary
- remove manual title field and derive suggestion titles from descriptions
- enable night mode with theme provider and toggle

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 6 errors, 11 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68af509803b0832ea5c56e96edfd161f